### PR TITLE
:sparkles:(database): add PDO class for database connection

### DIFF
--- a/serveur/app/core/Connexion.php
+++ b/serveur/app/core/Connexion.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+class Database {
+    private static ?PDO $instance = null;
+
+    private function construct() {}
+    private function clone() {}
+
+    public static function getConnection(): PDO {
+        if (self::$instance === null) {
+            $db_config = [
+                'SGBD' => 'mysql',
+                'HOST' => 'devbdd.iutmetz.univ-lorraine.fr',
+                'DB_NAME' => 'trivino7u_SAE4',
+                'USER' => 'trivino7u_appli',
+                'PASSWORD' => 'leadiego'
+            ];
+
+            try {
+                self::$instance = new PDO(
+                    "{$db_config['SGBD']}:host={$db_config['HOST']};dbname={$db_config['DB_NAME']};charset=utf8",
+                    $db_config['USER'],
+                    $db_config['PASSWORD'],
+                    [
+                        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                        PDO::ATTR_EMULATE_PREPARES => false
+                    ]
+                );
+            } catch (PDOException $e) {
+                die("Erreur de connexion : " . $e->getMessage());
+            }
+        }
+        return self::$instance;
+    }
+}


### PR DESCRIPTION
### Introduces a Singleton-Based `Database` Class for Connection Management  

This pull request refactors database connection handling by introducing a new `Database` class that follows the singleton pattern. This ensures that only one PDO instance is created and reused throughout the application, improving efficiency and consistency.  

#### Key Changes:  

✅ **Added `Database` class** in `serveur/app/core/Connexion.php` to manage database connections using the singleton pattern:  
- Declares a private static property `$instance` to store the PDO instance.  
- Implements a private constructor and disables cloning to prevent multiple instantiations.  
- Provides a static method `getConnection()` that initializes and returns a PDO instance if none exists, with proper error handling and configuration settings.  

This approach prevents unnecessary database connections, enhances performance, and ensures a centralized connection management strategy.  